### PR TITLE
Add adapter for Zend\Http\Client.

### DIFF
--- a/src/Service/Request/ZendHttpClient.php
+++ b/src/Service/Request/ZendHttpClient.php
@@ -1,0 +1,41 @@
+<?php
+namespace LosReCaptcha\Service\Request;
+
+use LosReCaptcha\Service\ReCaptcha;
+use Zend\Http\Client;
+
+final class ZendHttpClient implements RequestInterface
+{
+    /**
+     * HTTP client
+     *
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * Constructor
+     *
+     * @param Client $client HTTP client
+     */
+    public function __construct(Client $client = null)
+    {
+        $this->client = $client ? $client : new Client();
+    }
+
+    /**
+     * Submit ReCaptcha API request, return response body.
+     *
+     * @param Parameters $params ReCaptcha parameters
+     *
+     * @return string
+     */
+    public function send(Parameters $params)
+    {
+        $this->client->setUri(ReCaptcha::VERIFY_SERVER);
+        $this->client->setRawBody($params->toQueryString());
+        $this->client->setEncType('application/x-www-form-urlencoded');
+        $result = $this->client->setMethod('POST')->send();
+        return $result ? $result->getBody() : null;
+    }
+}


### PR DESCRIPTION
Since version 2.0, this code has been hard-coded to use Curl; however, I still need to wrap this around Zend\Http\Client to share settings with other portions of my application. This adapter makes that possible.